### PR TITLE
fix indentation of .pre-commit-config.yaml samples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See [pre-commit](https://github.com/pre-commit/pre-commit) for instructions
 Sample `.pre-commit-config.yaml`:
 
 ```yaml
--   repo: https://github.com/mxr/sync-pre-commit-deps
+  - repo: https://github.com/mxr/sync-pre-commit-deps
     rev: v0.0.1
     hooks:
     -   id: sync-pre-commit-deps
@@ -34,11 +34,11 @@ Ensures tools which declare `flake8` and `black` as additional dependencies will
 
 ```diff
  repos:
- -   repo: https://github.com/PyCQA/flake8
+   - repo: https://github.com/PyCQA/flake8
      rev: 6.0.0
      hooks:
      -   id: flake8
- -   repo: https://github.com/asottile/yesqa
+   - repo: https://github.com/asottile/yesqa
      rev: v1.5.0
      hooks:
      -   id: yesqa

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Sample `.pre-commit-config.yaml`:
   - repo: https://github.com/mxr/sync-pre-commit-deps
     rev: v0.0.1
     hooks:
-    -   id: sync-pre-commit-deps
+      - id: sync-pre-commit-deps
 ```
 
 ## cli
@@ -37,12 +37,12 @@ Ensures tools which declare `flake8` and `black` as additional dependencies will
    - repo: https://github.com/PyCQA/flake8
      rev: 6.0.0
      hooks:
-     -   id: flake8
+       - id: flake8
    - repo: https://github.com/asottile/yesqa
      rev: v1.5.0
      hooks:
-     -   id: yesqa
+       - id: yesqa
          additional_dependencies:
--        -   flake8==5.0.0
-+        -   flake8==6.0.0
+-        - flake8==5.0.0
++        - flake8==6.0.0
 ```


### PR DESCRIPTION
If pasting as is, get error:
```
❯ pre-commit run --all-files
An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml
=====> while parsing a block mapping
  in "<unicode string>", line 1, column 1
did not find expected key
  in "<unicode string>", line 30, column 1
Check the log at /Users/corneliusromer/.cache/pre-commit/pre-commit.log
```

