### PR TITLE
Add `mypy` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ sync-pre-commit-deps path/to/.pre-commit-config.yaml
 
 ## what it does
 
-Ensures tools which declare `flake8` and `black` as additional dependencies will have those versions synced with the `flake8` and `black` versions in the rest of the config. For example, `flake8` under `yesqa` is updated from `5.0.0` to `6.0.0`.
+Ensures tools which declare `flake8`, `black`, or `mypy` as additional dependencies will have those versions synced with the `flake8`, `black`, or `mypy` versions in the rest of the config. For example, `flake8` under `yesqa` is updated from `5.0.0` to `6.0.0`.
 
 ```diff
  repos:

--- a/sync_pre_commit_deps.py
+++ b/sync_pre_commit_deps.py
@@ -56,8 +56,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     for repo in loaded['repos']:
         for hook in repo['hooks']:
             if (hid := hook['id']) in SUPPORTED:
-                if hook_rev := re.match(r'[vV]?(?P<rev>[.\d]+)$', repo['rev']):
-                    versions[hid] = hook_rev.group('rev')
+                hook_rev = re.match(r'[vV]?(?P<rev>.+)$', repo['rev'])
+                # assert for mypy
+                assert hook_rev is not None, f'Invalid rev {repo["rev"]!r}'
+                versions[hid] = hook_rev.group('rev')
 
     updated = []
     for repo in loaded['repos']:

--- a/sync_pre_commit_deps.py
+++ b/sync_pre_commit_deps.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import argparse
+import re
 from collections.abc import Sequence
 
 import ruamel.yaml
 
-SUPPORTED = frozenset(('black', 'flake8'))
+SUPPORTED = frozenset(('black', 'flake8', 'mypy'))
 
 
 _ARGUMENT_HELP_TEMPLATE = (
@@ -55,7 +56,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     for repo in loaded['repos']:
         for hook in repo['hooks']:
             if (hid := hook['id']) in SUPPORTED:
-                versions[hid] = repo['rev']
+                if hook_rev := re.match(r'[vV]?(?P<rev>[.\d]+)$', repo['rev']):
+                    versions[hid] = hook_rev.group('rev')
 
     updated = []
     for repo in loaded['repos']:

--- a/sync_pre_commit_deps.py
+++ b/sync_pre_commit_deps.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import re
 from collections.abc import Sequence
 
 import ruamel.yaml
@@ -56,10 +55,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     for repo in loaded['repos']:
         for hook in repo['hooks']:
             if (hid := hook['id']) in SUPPORTED:
-                hook_rev = re.match(r'[vV]?(?P<rev>.+)$', repo['rev'])
-                # assert for mypy
-                assert hook_rev is not None, f'Invalid rev {repo["rev"]!r}'
-                versions[hid] = hook_rev.group('rev')
+                # `mirrors-mypy` uses versions with a 'v' prefix, so we have to
+                # strip it out to get the mypy version.
+                cleaned_rev = repo['rev'].removeprefix('v')
+                versions[hid] = cleaned_rev
 
     updated = []
     for repo in loaded['repos']:

--- a/tests/sync_pre_commit_deps_test.py
+++ b/tests/sync_pre_commit_deps_test.py
@@ -25,7 +25,7 @@ def test_main_noop(tmpdir):
     assert cfg.read() == s
 
 
-def test_main_writes_both(tmpdir):
+def test_main_writes_all(tmpdir):
     cfg = tmpdir.join('.pre-commit-config.yaml')
     cfg.write(
         'repos:\n'
@@ -44,7 +44,12 @@ def test_main_writes_both(tmpdir):
         '    rev: 6.0.0\n'
         '    hooks:\n'
         '    -   id: flake8\n'
-        # all 3 below should be rewritten
+        # gives the `mypy` version
+        '-   repo: https://github.com/pre-commit/mirrors-mypy\n'
+        '    rev: v1.13.0\n'
+        '    hooks:\n'
+        '    -   id: mypy\n'
+        # all repos below should have their additional_dependencies rewritten
         '-   repo: https://github.com/asottile/yesqa\n'
         '    rev: v1.5.0\n'
         '    hooks:\n'
@@ -57,13 +62,20 @@ def test_main_writes_both(tmpdir):
         '    -   id: blacken-docs\n'
         '        additional_dependencies:\n'
         '        -   black==22.12.0\n'
+        '-   repo: https://github.com/nbQA-dev/nbQA\n'
+        '    rev: 1.9.1\n'
+        '    hooks:\n'
+        '    -   id: nbqa-mypy\n'
+        '        additional_dependencies:\n'
+        '        -   mypy==0.910\n'
         '-   repo: https://github.com/example/example\n'
         '    rev: v1.0.0\n'
         '    hooks:\n'
         '    -   id: example\n'
         '        additional_dependencies:\n'
         '        -   black==22.12.0\n'
-        '        -   flake8==5.0.0\n',
+        '        -   flake8==5.0.0\n'
+        '        -   mypy==0.123\n',
     )
 
     assert main((str(cfg),))
@@ -82,6 +94,10 @@ def test_main_writes_both(tmpdir):
         '    rev: 6.0.0\n'
         '    hooks:\n'
         '    -   id: flake8\n'
+        '-   repo: https://github.com/pre-commit/mirrors-mypy\n'
+        '    rev: v1.13.0\n'
+        '    hooks:\n'
+        '    -   id: mypy\n'
         '-   repo: https://github.com/asottile/yesqa\n'
         '    rev: v1.5.0\n'
         '    hooks:\n'
@@ -94,6 +110,12 @@ def test_main_writes_both(tmpdir):
         '    -   id: blacken-docs\n'
         '        additional_dependencies:\n'
         '        -   black==23.3.0\n'
+        '-   repo: https://github.com/nbQA-dev/nbQA\n'
+        '    rev: 1.9.1\n'
+        '    hooks:\n'
+        '    -   id: nbqa-mypy\n'
+        '        additional_dependencies:\n'
+        '        -   mypy==1.13.0\n'
         '-   repo: https://github.com/example/example\n'
         '    rev: v1.0.0\n'
         '    hooks:\n'
@@ -101,6 +123,7 @@ def test_main_writes_both(tmpdir):
         '        additional_dependencies:\n'
         '        -   black==23.3.0\n'
         '        -   flake8==6.0.0\n'
+        '        -   mypy==1.13.0\n'
     )
 
 
@@ -117,15 +140,23 @@ def test_main_no_dep_on_one_and_writes_other(tmpdir):
         '    hooks:\n'
         '    -   id: yesqa\n'
         '        additional_dependencies:\n'
-        # should not be rewritten because target version can't be found
+        # should not be rewritten because target versions can't be found
         '        -   flake8==5.0.0\n'
+        '        -   mypy==0.910\n'
         '-   repo: https://github.com/adamchainz/blacken-docs\n'
         '    rev: 1.15.0\n'
         '    hooks:\n'
         '    -   id: blacken-docs\n'
         '        additional_dependencies:\n'
         # should be rewritten
-        '        -   black==22.12.0\n',
+        '        -   black==22.12.0\n'
+        '-   repo: https://github.com/nbQA-dev/nbQA\n'
+        '    rev: 1.9.1\n'
+        '    hooks:\n'
+        '    -   id: nbqa-mypy\n'
+        '        additional_dependencies:\n'
+        # should not be rewritten because target version can't be found
+        '        -   mypy==0.123',
     )
 
     assert main((str(cfg),))
@@ -142,10 +173,17 @@ def test_main_no_dep_on_one_and_writes_other(tmpdir):
         '    -   id: yesqa\n'
         '        additional_dependencies:\n'
         '        -   flake8==5.0.0\n'
+        '        -   mypy==0.910\n'
         '-   repo: https://github.com/adamchainz/blacken-docs\n'
         '    rev: 1.15.0\n'
         '    hooks:\n'
         '    -   id: blacken-docs\n'
         '        additional_dependencies:\n'
         '        -   black==23.3.0\n'
+        '-   repo: https://github.com/nbQA-dev/nbQA\n'
+        '    rev: 1.9.1\n'
+        '    hooks:\n'
+        '    -   id: nbqa-mypy\n'
+        '        additional_dependencies:\n'
+        '        -   mypy==0.123\n'
     )


### PR DESCRIPTION
Hello,

This is one of my first real PRs 😅 please forgive me

I wonder if we can add support for `mypy` as well. I often have to sync my `mypy` requirements under other hooks, such as `nbqa`. For example:

```yaml
repos:
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v5.0.0
    hooks:
      - id: mixed-line-ending
      - id: trailing-whitespace

  - repo: https://github.com/pre-commit/mirrors-mypy
    rev: v1.13.0  # Updated automatically with `pre-commit autoupdate`
    hooks:
      - id: mypy
        args:
          - --install-types
          - --non-interactive
        additional_dependencies:
          - pytest

  - repo: https://github.com/nbQA-dev/nbQA
    rev: 1.9.1
    hooks:
      - id: nbqa-check-ast
      - id: nbqa-mypy
        additional_dependencies:
          - mypy==1.13.0  # Must be manually synced with the hook version above
        args:
          - --install-types
          - --non-interactive 
```

Thank you for your consideration! ~Moshe